### PR TITLE
CI: Windows: Actually build for specified target in matrix

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -479,7 +479,7 @@ jobs:
       - name: Build
         if: matrix.conf == 'cargo-build'
         run: |
-          cargo build --release
+          cargo build --release --target=${{ matrix.target }}
       - name: Test
         if: matrix.conf == 'cargo-test'
         run: |


### PR DESCRIPTION
I screwed up in #2688.

Currently the Arm64 job in Windows installs the aarch64 toolchain, but doesn't actually build for that target. In the `actions-rs/toolchain@v1` step, both the `override` and `default` [inputs](https://github.com/actions-rs/toolchain#inputs) are set to _true_, which I thought would enable build with this target directly. Turns out this isn't the case, only the _toolchain_ is made default and not the _target_.

This PR fixes that, but unfortunately now the Windows Arm64 build breaks.

